### PR TITLE
fix: gcMaskBitIterator mask index out of range

### DIFF
--- a/pkg/proc/gcmask.go
+++ b/pkg/proc/gcmask.go
@@ -71,7 +71,7 @@ func (b *gcMaskBitIterator) resetGCMask(addr Address) error {
 	}
 	// TODO: check gc mask
 	offset := addr.Sub(b.maskBase)
-	b.mask[offset/8/64] &= ^(1 << (offset / 8 % 64))
+	b.mask[offset/8/64+1] &= ^(1 << (offset / 8 % 64))
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
mask panic: runtime error: index out of range 

Fix: https://github.com/cloudwego/goref/issues/46
