### PR TITLE
proc: check for goroutine parse errors before using

### DIFF
--- a/pkg/proc/reference.go
+++ b/pkg/proc/reference.go
@@ -521,6 +521,10 @@ func ObjectReference(t *proc.Target, filename string) (*ObjRefScope, error) {
 	threadID := t.CurrentThread().ThreadID()
 	grs, _, _ := proc.GoroutinesInfo(t, 0, 0)
 	for _, gr := range grs {
+		if gr.Unreadable != nil {
+			logflags.DebuggerLogger().Warnf("unreadable goroutine err: %v", gr.Unreadable)
+			continue
+		}
 		s.g = &stack{}
 		lo, hi := getStack(gr)
 		if gr.Thread != nil {


### PR DESCRIPTION
This patch adds a check to ensure that gr.Unreadable has not been set prior to trying to use that G struct. Using a parsed G with an Unreadable error set will likely end in a nil pointer dereference (which is what ended up happening).

#### What type of PR is this?

fix: A bug fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

