### PR TITLE
fix: correct gcmask value in documentation

### DIFF
--- a/docs/principle.md
+++ b/docs/principle.md
@@ -122,7 +122,7 @@ To implement this hybrid approach, whenever we access an object's pointer using 
 
 <p align="center"><img src="https://github.com/user-attachments/assets/cb286079-a7bd-4ef4-9c07-21eb8eb7fd80" width="60%"></p>
 
-For example, when accessing the `Object` mentioned above, its gcmask is `1010`. After reading field A, the gcmask becomes `1000`. If field C isn't accessed due to type coercion, it will be accounted for during the final GC marking scan.
+For example, when accessing the `Object` mentioned above, its gcmask is `1001`. After reading field A, the gcmask becomes `1000`. If field C isn't accessed due to type coercion, it will be accounted for during the final GC marking scan.
 
 Beyond type coercion, out-of-bounds memory references are another common issue. For instance, in the earlier example code `var b *int64 = &echo().B`, both fields A and C belong to memory that cannot be scanned through DWARF types and will also be accounted for during the final scan.
 


### PR DESCRIPTION
## Bug

Fixes #66 — The gcmask value in the documentation example was incorrect.

## Fix

Changed  to  for the Object struct's gcmask.

## Analysis

Given the Object structure:
```go
type Object struct {
    A string    // 16 bytes (2 words) - pointer to data + length
    B int64     // 8 bytes (1 word) - not a pointer  
    C *[]byte   // 8 bytes (1 word) - pointer
}
```

The gcmask indicates which 8-byte aligned addresses contain pointers:
- `base+0`: A string (contains pointer to string data) - **bit 1**
- `base+8`: A string length (not a pointer) - **bit 0**  
- `base+16`: B int64 (not a pointer) - **bit 0**
- `base+24`: C *[]byte (pointer) - **bit 1**

Therefore, the correct gcmask is **1001** (reading bits from left to right for base+0, base+8, base+16, base+24).

## Testing

Verified by analyzing the memory layout and pointer positions in the Object struct.

Greetings, saschabuehrle